### PR TITLE
Catalog deploy script

### DIFF
--- a/catalog/package.json
+++ b/catalog/package.json
@@ -24,7 +24,8 @@
     "build": "tsc -b --pretty",
     "dev": "tsc --watch --pretty",
     "lint:check": "eslint . --ext .ts --color --ignore-path ../.eslintignore",
-    "lint:fix": "eslint . --ext .ts --color --fix --ignore-path ../.eslintignore"
+    "lint:fix": "eslint . --ext .ts --color --fix --ignore-path ../.eslintignore",
+    "deploy": "scripts/deploy"
   },
   "bugs": {
     "url": "https://github.com/fusebit/packages/issues"

--- a/catalog/scripts/deploy
+++ b/catalog/scripts/deploy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+if [ "$1" == "" ]; then echo "ERROR: Specify the destination directory for the feeds, e.g. `npm run deploy {directory}`"; exit 1; fi
+echo Deploying feeds to $1
+node $SCRIPTPATH/../libc/index.js feed_connector > $1/connectorsFeed.json
+node $SCRIPTPATH/../libc/index.js feed_integration > $1/integrationsFeed.json
+ls -al $1


### PR DESCRIPTION
A simple script that generates and copies over the connector and integration feeds to a specified directory. Found it helpful when developing locally. 