### PR TITLE
Fix discord configuration

### DIFF
--- a/src/discord/discord-connector/src/index.ts
+++ b/src/discord/discord-connector/src/index.ts
@@ -7,6 +7,7 @@ const TOKEN_URL = 'https://discord.com/api/oauth2/token';
 const AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize';
 const REVOCATION_URL = 'https://discord.com/api/oauth2/token/revoke';
 const SERVICE_NAME = 'Discord';
+const CONFIGURATION_SECTION = 'Fusebit Connector Configuration';
 
 class ServiceConnector extends OAuthConnector {
   static Service = Service;
@@ -44,22 +45,9 @@ class ServiceConnector extends OAuthConnector {
       ctx.body.uischema.elements.find((element: { label: string }) => element.label == 'OAuth2 Configuration').label =
         'Discord Configuration';
 
-      ctx.body.uischema.elements
-        .find((element: { label: string }) => element.label == 'Fusebit Connector Configuration')
-        .elements[0].elements[1].elements.push({
-          type: 'Control',
-          scope: '#/properties/botToken',
-          options: {
-            format: 'password',
-          },
-        });
-
-      ctx.body.uischema.elements
-        .find((element: { label: string }) => element.label == 'Fusebit Connector Configuration')
-        .elements[0].elements[1].elements.push({
-          type: 'Control',
-          scope: '#/properties/applicationPublicKey',
-        });
+      this.addConfigurationElement(ctx, CONFIGURATION_SECTION, 'botToken', 'password');
+      this.addConfigurationElement(ctx, CONFIGURATION_SECTION, 'applicationPublicKey');
+      this.addConfigurationElement(ctx, CONFIGURATION_SECTION, 'extraParams');
 
       // Adjust the data schema
       ctx.body.schema.properties.scope.description = 'Space separated scopes to request from your Discord App';
@@ -69,9 +57,13 @@ class ServiceConnector extends OAuthConnector {
         title: 'Discord Application Bot Token',
         type: 'string',
       };
-      ctx.body.schema.properties.botToken = {
+      ctx.body.schema.properties.applicationPublicKey = {
         title: 'Discord Public Key',
         type: 'string',
+      };
+      ctx.body.schema.properties.extraParams = {
+        title: 'Bot Permissions',
+        type: 'integer',
       };
     });
 

--- a/src/oauth/oauth-connector/src/OAuthManager.ts
+++ b/src/oauth/oauth-connector/src/OAuthManager.ts
@@ -74,6 +74,43 @@ class OAuthConnector<S extends Connector.Types.Service = Connector.Service> exte
     return ctx.state.engine || new this.OAuthEngine(ctx.state.manager.config.configuration as IOAuthConfig);
   }
 
+  /**
+   *
+   * @param ctx Connector context
+   * @param configurationSection The section to configure (i.e Fusebit Connector Configuration)
+   * @param propertyScope A JSON schema reference value
+   * @param format How to display the control (i.e string, radio, password)
+   */
+  protected addConfigurationElement(
+    ctx: Connector.Types.Context,
+    configurationSection: string,
+    propertyScope: string,
+    format = 'string'
+  ): void {
+    const element = ctx.body.uischema.elements.find(
+      (element: { label: string }) => element.label == configurationSection
+    );
+    if (element) {
+      const newControl = {
+        type: 'Control',
+        scope: `#/properties/${propertyScope}`,
+        options: {
+          format,
+        },
+      };
+      const oddRow = element.elements[0].elements.find(
+        (rowElement: { elements: string | any[] }) => rowElement.elements.length !== 2
+      );
+      if (oddRow) {
+        oddRow?.elements.push(newControl);
+      } else {
+        element.elements[0].elements.push({ type: 'VerticalLayout', elements: [newControl] });
+      }
+    } else {
+      ctx.body = ctx.throw(`Invalid configuration section ${configurationSection}`);
+    }
+  }
+
   constructor() {
     super();
 


### PR DESCRIPTION
This PR fixes Discord configuration + the layout of the config since this specific connector supports some extra fields:
- public key
- bot permissions
- bot token

how it looks:
<img width="1278" alt="Screen Shot 2021-12-09 at 10 36 07 PM" src="https://user-images.githubusercontent.com/4001529/145513554-72259646-5453-431b-b246-681b590f54bc.png">

Note: I don't like it 100% how it looks but I think we should extend this into a new section (we need to discuss it) - but this will fix the Discord issue in prod!

