### PR TITLE
Fix unhandled webhook error when revoking authorization from a GitHub App

### DIFF
--- a/src/githubapp/githubapp-connector/src/Service.ts
+++ b/src/githubapp/githubapp-connector/src/Service.ts
@@ -13,6 +13,12 @@ class Service extends OAuthConnector.Service {
   }
 
   public getAuthIdFromEvent(ctx: Connector.Types.Context, event: any): string {
+    // GitHub will send automatically a Webhook when a GitHub user authorization is revoked
+    // Notice this is a different concept of Uninstalling a GitHub App.
+    if (event.data.action === 'revoked') {
+      // Since this is a specific user operation, return the user id
+      return event.data.sender.id;
+    }
     return event.data.installation.id;
   }
 


### PR DESCRIPTION
This PR will fix this error when revoking a GitHub App Authorization:
<img width="831" alt="Screen Shot 2021-12-23 at 11 15 49 AM" src="https://user-images.githubusercontent.com/4001529/147266476-a3fdae62-ae42-4f71-9cfe-25ee0c4116c6.png">

GitHub sends a Webhook automatically when a user authorization is revoked from a GitHub App, notice this concept is different from uninstalling a GitHub App, that case is handled properly.

