### PR TITLE
Handle properly GitHub Webhook undefined action

### DIFF
--- a/src/githubapp/githubapp-connector/src/Service.ts
+++ b/src/githubapp/githubapp-connector/src/Service.ts
@@ -8,7 +8,7 @@ class Service extends OAuthConnector.Service {
   public getEventsFromPayload(ctx: Connector.Types.Context): any {
     const event = ctx.req.headers['x-github-event'];
     const action = ctx.req.body.action || ctx.req.body.ref_type;
-    const type = `${event}.${action}`;
+    const type = action ? `${event}.${action}` : event;
     return [{ data: ctx.req.body, type }];
   }
 


### PR DESCRIPTION
Certain GitHub Webhooks don't send an action, just an event, like a push event, while testing I've found an issue where the push event was sent like push.undefined, this PR fixes that. 