### PR TITLE
Feed updates in support of the GSheet Add-On

### DIFF
--- a/catalog/feed_connector/salesforce/snippets/run-query.js
+++ b/catalog/feed_connector/salesforce/snippets/run-query.js
@@ -1,4 +1,4 @@
-async function sfdcRunQuery(ctx, jql) {
+async function sfdcRunQuery(ctx, soql) {
   // For the Salesforce SDK documentation, see https://jsforce.github.io/.
   const sfdcClient = await integration.tenant.getSdkByTenant(
     ctx,
@@ -6,21 +6,40 @@ async function sfdcRunQuery(ctx, jql) {
     ctx.params.tenantId || '<% defaultTenantId %>'
   );
 
-  return await sfdcClient.query(jql || 'SELECT count() FROM Contact');
+  return await sfdcClient.query(soql || 'SELECT count() FROM Contact');
+}
+
+async function sfdcRunQueryMore(ctx, nextRecordsUrl) {
+  // For the Salesforce SDK documentation, see https://jsforce.github.io/.
+  const sfdcClient = await integration.tenant.getSdkByTenant(
+    ctx,
+    '<% connectorName %>',
+    ctx.params.tenantId || '<% defaultTenantId %>'
+  );
+
+  return await sfdcClient.queryMore(nextRecordsUrl);
 }
 
 const code = `
 /**
- * Run Salesforce JQL query.
+ * Run Salesforce SOQL query.
  * 
  * @param ctx {FusebitContext} Fusebit Context
- * @param jql {string} Salesforce JQL query
+ * @param soql {string} Salesforce SOQL query
  */
 ${sfdcRunQuery.toString()}
+
+/**
+ * Get more results for a previously ran Salesforce SOQL query.
+ * 
+ * @param ctx {FusebitContext} Fusebit Context
+ * @param nextRecordsUrl {string} The nextRecordsUrl returned from previous, partial query result.
+ */
+${sfdcRunQueryMore.toString()}
 `;
 
 module.exports = {
-  name: 'Run JQL query',
-  description: 'Run a JQL query in Salesforce.',
+  name: 'Run SOQL query',
+  description: 'Run a SOQL query in Salesforce.',
   code,
 };

--- a/catalog/feed_connector/slack/connector/fusebit.json
+++ b/catalog/feed_connector/slack/connector/fusebit.json
@@ -8,7 +8,7 @@
     "mode": {
       "useProduction": false
     },
-    "scope": "chat:write users:read channels:read channels:join chat:write.public",
+    "scope": "chat:write users:read channels:read channels:join chat:write.public files:write",
     "clientId": "<% global.consts.random %>",
     "clientSecret": "<% global.consts.random %>",
     "refreshErrorLimit": 100000,

--- a/catalog/feed_connector/slack/snippets/send-message.js
+++ b/catalog/feed_connector/slack/snippets/send-message.js
@@ -11,10 +11,15 @@ async function slackSendMessage(ctx, message, channel) {
     channel = slackClient.fusebit.credentials.authed_user.id;
   }
 
-  return slackClient.chat.postMessage({
-    text: message || 'Hello world from Fusebit!',
-    channel,
-  });
+  return typeof message === 'object'
+    ? slackClient.chat.postMessage({
+        channel,
+        ...message,
+      })
+    : slackClient.chat.postMessage({
+        channel,
+        text: message || 'Hello world from Fusebit!',
+      });
 }
 
 const code = `
@@ -22,7 +27,7 @@ const code = `
  * Sends a message to a Slack channel. 
  * 
  * @param ctx {FusebitContext} Fusebit Context of the request
- * @param message {string} The message (in Slack markdown) to send
+ * @param message {string|object} The message (in Slack markdown) to send, or the postMessage payload (advanced).
  * @param {channel} [undefined] Optional Slack channel ID or channel name to send the message to. If not specified, a DM is sent.
  */
 ${slackSendMessage.toString()}

--- a/catalog/feed_connector/slack/snippets/upload-file.js
+++ b/catalog/feed_connector/slack/snippets/upload-file.js
@@ -1,0 +1,31 @@
+async function slackUploadFile(ctx, payload) {
+  // For the Slack SDK documentation, see https://slack.dev/node-slack-sdk/web-api.
+  const slackClient = await integration.tenant.getSdkByTenant(
+    ctx,
+    '<% connectorName %>',
+    ctx.params.tenantId || '<% defaultTenantId %>'
+  );
+
+  if (!payload?.channels) {
+    // Use the Slack user ID of the authorized user as the channel ID to send a Direct Message
+    payload.channels = slackClient.fusebit.credentials.authed_user.id;
+  }
+
+  return slackClient.files.upload(payload);
+}
+
+const code = `
+/**
+ * Upload a file to a Slack channel. 
+ * 
+ * @param ctx {FusebitContext} Fusebit Context of the request
+ * @param message {payload} The file upload payload.
+ */
+${slackUploadFile.toString()}
+`;
+
+module.exports = {
+  name: 'Upload a file to a channel',
+  description: 'Upload a file to a Slack channel.',
+  code,
+};


### PR DESCRIPTION
1. Fix copy in the SFDC snippet to use "SOQL" instead of "JQL". Confusion with another service ;)
2. Add support to paging to SFDC query snippet.
3. Add "files:write" scope to Slack connector template to allow for sending files (e.g. images) in addition to text messages.
4. Improve slackSendMessage snippet to allow low lever control over message format. 
5. Add slackUploadFile snippet for sending files to Slack.
6. Add support for passing Google Sheet chart images to the Google Sheets Add-On integration template. 
7. Fix some copy in the Google Sheets Add-On integration template. 
8. Better experience when authorizing connectors in the Google Sheets Add-On integration template. 