### PR TITLE
Update Slash command webhook to use handler properly interactivity

### DIFF
--- a/src/slack/slack-connector/src/Service.ts
+++ b/src/slack/slack-connector/src/Service.ts
@@ -57,12 +57,6 @@ class Service extends OAuthConnector.Service {
       return `slash-command${event.command}`;
     }
 
-    // Handle interactive payload (Read more at https://api.slack.com/interactivity/handling#payloads)
-    if (event.payload) {
-      const payload = JSON.parse(event.payload);
-      return `interactive-message/${payload.type}`;
-    }
-
     return event.type;
   }
 }


### PR DESCRIPTION
Didn't want to complicate our event API, Interactivity will be handled under **/:componentName/webhook/:event** as usual instead of using a new path for interactive messages.