### PR TITLE
Log request exceptions to console.log

### DIFF
--- a/src/framework/src/DefaultRoutes.ts
+++ b/src/framework/src/DefaultRoutes.ts
@@ -1,4 +1,4 @@
-import { HttpRouter, EventRouter, FusebitContext, Next } from './router';
+import { HttpRouter, FusebitContext, Next } from './router';
 import { IInstanceConnectorConfig } from './ConnectorManager';
 import Connector from './client/Connector';
 
@@ -6,7 +6,6 @@ import { validate } from './middleware';
 import { schema as eventSchema } from './validation/event';
 
 const router = new HttpRouter();
-const eventRouter = new EventRouter(router);
 
 /**
  * Annotate the health status with information on whether the vendor code loaded correctly.
@@ -67,7 +66,5 @@ router.post('/event/:eventMode', validate(eventSchema), async (ctx: FusebitConte
 
   ctx.body = result;
 });
-
-eventRouter.on('/lifecycle/startup', async (ctx, next) => next());
 
 export default router;

--- a/src/framework/src/Manager.ts
+++ b/src/framework/src/Manager.ts
@@ -115,8 +115,6 @@ class Manager {
     // Add the default routes - these will get overruled by any routes added by the vendor or during the
     // startup phase.
     this.router.use(DefaultRoutes.routes());
-
-    this.invoke('/lifecycle/startup', {});
   }
 
   /**


### PR DESCRIPTION
Additionally, remove vestigial lifecycle events which were poorly implemented and conflicted with `router.use` idioms in the vendor routes section - for example, the OAuthManager expected the baseUrl to be set, but the lifecycle event is prior to that point in the process, which caused errors in the engine.