### PR TITLE
Fix AWS Connector Files

### DIFF
--- a/src/aws/aws-connector/package.json
+++ b/src/aws/aws-connector/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "jest --config=./jest.config.ts --passWithNoTests",
     "tsc:version": "tsc --version",
-    "build": "tsc -b --pretty && mkdir -p libc/template/ && cp -r src/template/ libc/template/",
+    "build": "tsc -b --pretty && cp -r src/template libc",
     "dev": "tsc --watch --pretty",
     "lint:check": "eslint . --ext .ts --color --ignore-path ../../../.eslintignore",
     "lint:fix": "eslint . --ext .ts --color --fix --ignore-path ../../../.eslintignore"


### PR DESCRIPTION
Why can't macos use the same coreutils as linux :(